### PR TITLE
Add sprint α bootstrap code

### DIFF
--- a/apps/web/app/constellation/page.tsx
+++ b/apps/web/app/constellation/page.tsx
@@ -1,0 +1,13 @@
+import { ParticleField } from "@nexus/particle-engine";
+import { useNexus } from "@nexus/store";
+import ConstellationHTML from "@nexus/ui/static/ConstellationHTML";
+
+export default function ConstellationPage() {
+  const { activeLayer } = useNexus();
+  return (
+    <>
+      <ParticleField />
+      <ConstellationHTML activeLayer={activeLayer}/>
+    </>
+  );
+}

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,0 +1,13 @@
+import "@nexus/ui/globals.css";
+import { NyraDock } from "@nexus/ui/NyraDock";
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="bg-[color:var(--bg-primary)]">
+        {children}
+        <NyraDock /> {/* floating \ud83e\udd16 accessible everywhere */}
+      </body>
+    </html>
+  );
+}

--- a/apps/web/app/messenger/page.tsx
+++ b/apps/web/app/messenger/page.tsx
@@ -1,0 +1,13 @@
+import { ParticleField } from "@nexus/particle-engine";
+import { useNexus } from "@nexus/store";
+import MessengerHTML from "@nexus/ui/static/MessengerHTML";
+
+export default function MessengerPage() {
+  const { activeLayer } = useNexus();
+  return (
+    <>
+      <ParticleField />
+      <MessengerHTML activeLayer={activeLayer}/>
+    </>
+  );
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,0 +1,1 @@
+export { default } from "./threads/page";

--- a/apps/web/app/simulator/page.tsx
+++ b/apps/web/app/simulator/page.tsx
@@ -1,0 +1,13 @@
+import { ParticleField } from "@nexus/particle-engine";
+import { useNexus } from "@nexus/store";
+import SimulatorHTML from "@nexus/ui/static/SimulatorHTML";
+
+export default function SimulatorPage() {
+  const { activeLayer } = useNexus();
+  return (
+    <>
+      <ParticleField />
+      <SimulatorHTML activeLayer={activeLayer}/>
+    </>
+  );
+}

--- a/apps/web/app/threads/page.tsx
+++ b/apps/web/app/threads/page.tsx
@@ -1,0 +1,13 @@
+import { ParticleField } from "@nexus/particle-engine";
+import { useNexus } from "@nexus/store";
+import ThreadsHTML from "@nexus/ui/static/ThreadsHTML";
+
+export default function ThreadsPage() {
+  const { activeLayer } = useNexus();
+  return (
+    <>
+      <ParticleField />
+      <ThreadsHTML activeLayer={activeLayer}/>
+    </>
+  );
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "web",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "tailwindcss": "^3.4.0",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0"
+  }
+}

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,0 +1,9 @@
+import type { Config } from "tailwindcss";
+import nexusTokens from "@nexus/ui/plugin";
+
+export default {
+  content: ["./app/**/*.{ts,tsx}"],
+  darkMode: "class",
+  theme: { extend: {} },
+  plugins: [nexusTokens]
+} satisfies Config;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "nexus-monorepo",
+  "private": true,
+  "packageManager": "pnpm@9.1.2",
+  "scripts": {
+    "dev": "turbo run dev --parallel",
+    "build": "turbo run build",
+    "lint": "turbo run lint",
+    "storybook": "turbo run storybook --parallel",
+    "seed": "pnpm --filter prisma exec ts-node prisma/seed.ts"
+  },
+  "devDependencies": {
+    "turbo": "^1.13.0",
+    "typescript": "^5.5.0",
+    "eslint": "^9.0.0",
+    "prettier": "^3.2.5"
+  }
+}

--- a/packages/particle-engine/index.tsx
+++ b/packages/particle-engine/index.tsx
@@ -1,0 +1,15 @@
+"use client";
+import { Canvas } from "@react-three/fiber";
+import { Points, PointMaterial } from "@react-three/drei";
+
+export function ParticleField({ variant = "ambient" }: { variant?: "ambient"|"interactive" }) {
+  // tiny PoC; sampled points and slow drift
+  const count = variant === "ambient" ? 800 : 2000;
+  return (
+    <Canvas style={{ position: "fixed", inset: 0, zIndex: 0 }}>
+      <Points limit={count}>
+        <PointMaterial color="white" size={0.5} sizeAttenuation depthWrite={false}/>
+      </Points>
+    </Canvas>
+  );
+}

--- a/packages/particle-engine/package.json
+++ b/packages/particle-engine/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@nexus/particle-engine",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "index.tsx",
+  "exports": {
+    "./*": "./*"
+  }
+}

--- a/packages/store/index.ts
+++ b/packages/store/index.ts
@@ -1,0 +1,16 @@
+import create from "zustand";
+
+interface NexusState {
+  wallet?: string;
+  nexusBalance: number;
+  activeLayer: "cognitive" | "consensus" | "value";
+  nyraOpen: boolean;
+  set: <K extends keyof NexusState>(k: K, v: NexusState[K]) => void;
+}
+
+export const useNexus = create<NexusState>((set) => ({
+  nexusBalance: 1000,
+  activeLayer: "cognitive",
+  nyraOpen: false,
+  set: (k, v) => set({ [k]: v } as any)
+}));

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@nexus/store",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "index.ts",
+  "exports": {
+    "./*": "./*"
+  }
+}

--- a/packages/ui/.storybook/main.ts
+++ b/packages/ui/.storybook/main.ts
@@ -1,0 +1,12 @@
+import type { StorybookConfig } from "@storybook/react-vite";
+
+const config: StorybookConfig = {
+  stories: ["../**/*.tsx"],
+  addons: ["@storybook/addon-essentials"],
+  framework: {
+    name: "@storybook/react-vite",
+    options: {}
+  }
+};
+
+export default config;

--- a/packages/ui/NyraDock.tsx
+++ b/packages/ui/NyraDock.tsx
@@ -1,0 +1,12 @@
+"use client";
+import { useNexus } from "@nexus/store";
+
+export function NyraDock() {
+  const { nyraOpen, set } = useNexus();
+  return (
+    <div style={{ position: "fixed", bottom: 20, right: 20 }}>
+      <button onClick={() => set("nyraOpen", !nyraOpen)}>NYRA</button>
+      {nyraOpen && <div>NYRA Dashboard</div>}
+    </div>
+  );
+}

--- a/packages/ui/design-tokens.ts
+++ b/packages/ui/design-tokens.ts
@@ -1,0 +1,11 @@
+export const tokens = {
+  color: {
+    primary: "#00ffcc",
+    secondary: "#00aaff",
+    accent: "#ff00ff",
+    bg: {
+      primary: "#0a0a0a",
+      secondary: "#1a1a2e"
+    }
+  }
+} as const;

--- a/packages/ui/globals.css
+++ b/packages/ui/globals.css
@@ -1,0 +1,5 @@
+/* global styles */
+body {
+  margin: 0;
+  font-family: sans-serif;
+}

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "@nexus/ui",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "index.ts",
+  "exports": {
+    "./*": "./*"
+  }
+}

--- a/packages/ui/plugin.ts
+++ b/packages/ui/plugin.ts
@@ -1,0 +1,14 @@
+import plugin from "tailwindcss/plugin";
+import { tokens } from "./design-tokens";
+
+export default plugin(({ addBase }) => {
+  addBase({
+    ":root": {
+      "--primary": tokens.color.primary,
+      "--secondary": tokens.color.secondary,
+      "--accent": tokens.color.accent,
+      "--bg-primary": tokens.color.bg.primary,
+      "--bg-secondary": tokens.color.bg.secondary
+    }
+  });
+});

--- a/packages/ui/static/ConstellationHTML.tsx
+++ b/packages/ui/static/ConstellationHTML.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+export default function ConstellationHTML({ activeLayer }: { activeLayer: string }) {
+  return <div>Constellation prototype. Active layer: {activeLayer}</div>;
+}

--- a/packages/ui/static/MessengerHTML.tsx
+++ b/packages/ui/static/MessengerHTML.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+export default function MessengerHTML({ activeLayer }: { activeLayer: string }) {
+  return <div>Messenger prototype. Active layer: {activeLayer}</div>;
+}

--- a/packages/ui/static/SimulatorHTML.tsx
+++ b/packages/ui/static/SimulatorHTML.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+export default function SimulatorHTML({ activeLayer }: { activeLayer: string }) {
+  return <div>Simulator prototype. Active layer: {activeLayer}</div>;
+}

--- a/packages/ui/static/ThreadsHTML.tsx
+++ b/packages/ui/static/ThreadsHTML.tsx
@@ -1,0 +1,5 @@
+"use client";
+
+export default function ThreadsHTML({ activeLayer }: { activeLayer: string }) {
+  return <div>Threads prototype. Active layer: {activeLayer}</div>;
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - "apps/*"
+  - "packages/*"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,28 @@
+datasource db { provider = "sqlite"; url = "file:./dev.db" }
+generator client { provider = "prisma-client-js" }
+
+model Thread {
+  id          Int      @id @default(autoincrement())
+  title       String
+  description String
+  authorType  String   // "human" | "ai" | "hybrid"
+  createdAt   DateTime @default(now())
+  nodes       Node[]
+}
+
+model Node {
+  id        Int      @id @default(autoincrement())
+  content   String
+  stake     Float
+  threadId  Int
+  thread    Thread   @relation(fields: [threadId], references: [id])
+  createdAt DateTime @default(now())
+}
+
+model AgentLog {
+  id        Int      @id @default(autoincrement())
+  agentId   String
+  action    String
+  payload   Json
+  createdAt DateTime @default(now())
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,18 @@
+import { PrismaClient } from "@prisma/client";
+const db = new PrismaClient();
+
+await db.thread.create({
+  data: {
+    title: "Quantum‑safe signature schemes",
+    description: "Exploring lattice‑based cryptography for post‑QKD era.",
+    authorType: "human",
+    nodes: {
+      create: [
+        { content: "Initial literature survey\u00a0\ud83d\udcda", stake: 50 },
+        { content: "NYRA‑generated summary of NTRU performance", stake: 10 }
+      ]
+    }
+  }
+});
+
+await db.$disconnect();

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "pipeline": {
+    "dev": { "cache": false, "dependsOn": ["^dev"] },
+    "build": { "outputs": [".next/**","dist/**"] },
+    "lint": {},
+    "storybook": { "outputs": [".storybook-static/**"] }
+  }
+}


### PR DESCRIPTION
## Summary
- add Next.js monorepo scaffold with Turborepo config
- include shared UI and store packages
- provide Prisma schema and seed script
- stub particle engine and pages

## Testing
- `pnpm lint` *(fails: unable to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_68514cc2e0948322a8ea1ed9c4b918aa